### PR TITLE
Fix glob pattern to avoid error

### DIFF
--- a/tool/cp/cp.cwl
+++ b/tool/cp/cp.cwl
@@ -21,7 +21,7 @@ outputs:
   renamed_file:
     type: File
     outputBinding:
-      glob: $(runtime.outdir)/$(inputs.renamed_name)
+      glob: $(inputs.renamed_name)
   stdout: stdout
   stderr: stderr
 stdout: cp-stdout.log


### PR DESCRIPTION
To avoid this error

```
cp.cwl:24:7: glob patterns must not start with '/'
```