### PR TITLE
Add tool/unwrap

### DIFF
--- a/test/tool/test_job/unwrap.yml
+++ b/test/tool/test_job/unwrap.yml
@@ -1,0 +1,1 @@
+input: 10  # type "Any" (optional)

--- a/tool/unwrap/unwrap.cwl
+++ b/tool/unwrap/unwrap.cwl
@@ -1,0 +1,20 @@
+#!/usr/bin/env cwl-runner
+cwlVersion: v1.0
+class: ExpressionTool
+doc: Returns `T` value from `T?` if the given value is not null. Otherwise fails with `permanentFailure`.
+inputs:
+  input:
+    type: Any?
+expression: |
+  ${
+    if (!inputs.input) {
+      throw new Error("Input is null but it should not");
+    }
+    return {
+      unwrapped: inputs.input,
+    };
+  }
+outputs:
+  unwrapped: Any
+requirements:
+  InlineJavascriptRequirement: {}

--- a/tool/unwrap/unwrap.yml
+++ b/tool/unwrap/unwrap.yml
@@ -1,0 +1,1 @@
+input: 'null'  # type "Any" (optional)


### PR DESCRIPTION
This PR adds `unwrap` tool, which returns `T` value from `T?` for any type `T` if the given value is not null. Otherwise fails with `permanentFailure`.

The name `unwrap` comes from [Option#unwap method in Rust](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap).