### PR TITLE
Add support for pair-end to bwa-mem.cwl

### DIFF
--- a/tool/bwa/mem/bwa-mem.cwl
+++ b/tool/bwa/mem/bwa-mem.cwl
@@ -41,7 +41,7 @@ inputs:
     label: "input fastq file to map (forward)"
     inputBinding:
       position: 2
-  fastq_forward:
+  fastq_reverse:
     type: File?
     label: "input fastq file to map (erverse)"
     inputBinding:

--- a/tool/bwa/mem/bwa-mem.cwl
+++ b/tool/bwa/mem/bwa-mem.cwl
@@ -36,11 +36,16 @@ inputs:
       - .bwt
       - .pac
       - .sa
-  input_fastq:
+  fastq_forward:
     type: File
-    label: "input fastq file to map"
+    label: "input fastq file to map (forward)"
     inputBinding:
       position: 2
+  fastq_forward:
+    type: File?
+    label: "input fastq file to map (erverse)"
+    inputBinding:
+      position: 3
 
 outputs:
   output:

--- a/tool/bwa/mem/bwa-mem.cwl
+++ b/tool/bwa/mem/bwa-mem.cwl
@@ -38,12 +38,12 @@ inputs:
       - .sa
   fastq_forward:
     type: File
-    label: "input fastq file to map (forward)"
+    label: "input fastq file to map (single-end or forward for pair-end)"
     inputBinding:
       position: 2
   fastq_reverse:
     type: File?
-    label: "input fastq file to map (erverse)"
+    label: "input fastq file to map (reverse for pair-end)"
     inputBinding:
       position: 3
 

--- a/tool/bwa/mem/bwa-mem.cwl
+++ b/tool/bwa/mem/bwa-mem.cwl
@@ -11,7 +11,7 @@ inputs:
   threads:
     type: int
     label: "number of threads"
-    defult: 4
+    default: 4
     inputBinding:
       prefix: -t
   output_sam:
@@ -20,6 +20,11 @@ inputs:
     default: "out.sam"
     inputBinding:
       prefix: -o
+  group_header_line:
+    type: string?
+    label: "read group header line such as '@RG\tID:foo\tSM:bar'"
+    inputBinding:
+      prefix: -R
   index_base:
     type: File
     label: "fasta file for index basename"


### PR DESCRIPTION
この PR は`bwa-mem.cwl` に以下の変更を行います。

- タイポ修正 `defult` -> `default`
- `group_header_line` パラメータの追加
- ペアエンド対応

上2つは対応済みですが、最後のペアエンド対応をどうしようか迷っています。
以下の方針が思いつきますが、どうしましょうか？

- `bwa mem` のヘルプメッセージの `bwa mem [options] <idxbase> <in1.fq> [in2.fq]` と合わせるため、`File?` 型の `input_fastq2` を追加する(合わせて `input_fastq` -> `input_fastq1` に変更)
  - 1, 2 よりは、`fastq_forward`, `fastq_reverse` の方がいいかもしれません
- `input_fastqs` の型を `File[]` に変更する

前者の場合かつ、パラメータ名を変更しない場合には、既存の `bwa-mem.cwl` を使っている他のワークフローには影響は出ません。
後者を採用する場合や、前者でパラメータ名の変更も加える場合には、既存のワークフローに影響が出ます。