### PR TITLE
fix the path to exec build.sh

### DIFF
--- a/test/tool/all_test
+++ b/test/tool/all_test
@@ -46,8 +46,8 @@ for tool_name in $(find ${tool_dir} -type f | grep cwl | sed -e 's/.*\///g' | se
   dockerfile=${each_tool_dir}/Dockerfile
   if [ -f ${dockerfile} ]; then
     echo "...docker build"
-    build_file=${each_tool_dir}/build.sh
-    bash ${build_file}
+    cd ${each_tool_dir}
+    bash build.sh
   if [ $? -ne 0 ]; then
     echo "[ERROR] Docker build is failed."
     exit 1


### PR DESCRIPTION
test コマンドと同じく all_test でも `test/tool` 以外のディレクトリからスクリプトを呼んだときにビルドスクリプトのパスが通らない問題を解決する