### PR TITLE
Fix output parameter for samtools-view.cwl

### DIFF
--- a/tool/samtools/view/samtools-view.cwl
+++ b/tool/samtools/view/samtools-view.cwl
@@ -31,7 +31,7 @@ inputs:
     inputBinding:
       position: 1
 outputs:
-  output_bam:
+  bam:
     type: File
     outputBinding:
       glob: "$(inputs.output_filename)"


### PR DESCRIPTION
この PR では `samtools-view.cwl` の validate 時に起きる以下のエラーメッセージを修正します。

```console
$ cwltool --validate samtools-view.cwl
...
samtools-view.cwl:16:3: object id `samtools-view.cwl#output_bam` previously defined
...
```

これは、入力パラメータと出力パラメータの両方で `output_bam` が定義されているためです。
出力パラメータ名を `output_bam` -> `bam` に変更することで、このエラーを修正します。
