### PR TITLE
Remove track_location from tool/wget

### DIFF
--- a/tool/wget/wget.cwl
+++ b/tool/wget/wget.cwl
@@ -24,12 +24,6 @@ inputs:
     doc: Use the basename of `url` parameter as an output file name. It is equivalent to `curl -O`.
     type: boolean
     default: false
-  track_location:
-    doc: Equivalent to `curl -L`
-    type: boolean
-    default: false
-    inputBinding:
-      prefix: --trusted-server-names
 outputs:
   downloaded:
     type: File


### PR DESCRIPTION
`alpine:3.9` イメージにインストールされている `wget` には、`track_location` パラメータで追加される `--trusted-server-names` が実装されていません。この PR では `track_location` パラメータを wget.cwl から削除します。

このオプションは教本中では単にダウンロードされるファイル名を与えられた URL と同じにするという用途として使われていると予想され、かつその機能は現状の wget.cwl でカバーされています。

サーバーが移動したときに追跡するためのオプションである `--trusted-serve-names` および `curl` の `-L` が本来の用途で使われていないのであれば、このパラメータを削除しても問題ないと思いますが、いかがでしょう？

---

他の解決策としては、`debian` や `ubuntu` イメージなどの `wget` (or `curl`) を使うことですが、これらのイメージには標準で `wget` も `curl` もインストールされていないため、新規に `Dockerfile` を作成する必要があります。

